### PR TITLE
Handle multiple slide boxes

### DIFF
--- a/tabbedSlideBox/tabSlideBox.js
+++ b/tabbedSlideBox/tabSlideBox.js
@@ -51,6 +51,19 @@ angular.module('tabSlideBox', [])
 					$ta.addClass("btm");
 				}
 				
+				//Handle multiple slide/scroll boxes
+				var handle = ta.querySelector('.slider').getAttribute('delegate-handle');
+				
+				var ionicSlideBoxDelegate = $ionicSlideBoxDelegate;
+				if(handle){
+					ionicSlideBoxDelegate = ionicSlideBoxDelegate.$getByHandle(handle);
+				}
+				
+				var ionicScrollDelegate = $ionicScrollDelegate;
+				if(handle){
+					ionicScrollDelegate = ionicScrollDelegate.$getByHandle(handle);
+				}
+				
 				function renderScrollableTabs(){
 					var iconsDiv = angular.element(ta.querySelector(".tsb-icons")), icons = iconsDiv.find("a"), wrap = iconsDiv[0].querySelector(".tsb-ic-wrp"), totalTabs = icons.length;
 					var scrollDiv = wrap.querySelector(".scroll");
@@ -58,7 +71,7 @@ angular.module('tabSlideBox', [])
 					angular.forEach(icons, function(value, key){
 					     var a = angular.element(value);
 					     a.on('click', function(){
-					    	 $ionicSlideBoxDelegate.slide(key);
+					    	 ionicSlideBoxDelegate.slide(key);
 					     });
 					});
 					
@@ -74,7 +87,7 @@ angular.module('tabSlideBox', [])
 					}
 					
 					$timeout(function() {
-						$ionicSlideBoxDelegate.slide(initialIndex);
+						ionicSlideBoxDelegate.slide(initialIndex);
 					}, 0);
 				}
 				function setPosition(index){
@@ -106,7 +119,7 @@ angular.module('tabSlideBox', [])
 								leftStr = 0;
 							}
 							//Use this scrollTo, so when scrolling tab manually will not flicker
-							$ionicScrollDelegate.scrollTo(Math.abs(leftStr), 0, true);
+							ionicScrollDelegate.scrollTo(Math.abs(leftStr), 0, true);
 						}
 					}
 					}


### PR DESCRIPTION
This fixes the buggy behaviour this library has when there are more than one slide box in the page. Before this, selecting one tab of tabbedSlideBox would trigger the event to all the slide boxes in the page, resulting in an unwanted sync.
If you want to be sure that your slide box will be handled as one, you can add the delegate-handle="infoHandler" attribute to the <ion-slide-box> tag.