### PR TITLE
Making onSlideMove optional and adding ON/OFF states

### DIFF
--- a/tabbedSlideBox/tabSlideBox.js
+++ b/tabbedSlideBox/tabSlideBox.js
@@ -60,6 +60,10 @@ angular.module('tabSlideBox', [])
 					     a.on('click', function(){
 					    	 $ionicSlideBoxDelegate.slide(key);
 					     });
+
+						if(a.attr('icon-off')) {
+							a.attr("class", a.attr('icon-off'));
+						}
 					});
 					
 					var initialIndex = attrs.tab;
@@ -83,10 +87,18 @@ angular.module('tabSlideBox', [])
 					
 					var middle = iconsDiv[0].offsetWidth/2;
 					var curEl = angular.element(icons[index]);
+					var prvEl = angular.element(iconsDiv[0].querySelector(".active"));
 					if(curEl && curEl.length){
 					var curElWidth = curEl[0].offsetWidth, curElLeft = curEl[0].offsetLeft;
 
-					angular.element(iconsDiv[0].querySelector(".active")).removeClass("active");
+					if(prvEl.attr('icon-off')) {
+						prvEl.attr("class", prvEl.attr('icon-off'));
+					}else{
+						prvEl.removeClass("active");
+					}
+					if(curEl.attr('icon-on')) {
+						curEl.attr("class", curEl.attr('icon-on'));
+					}
 					curEl.addClass("active");
 					
 					var leftStr = (middle  - (curElLeft) -  curElWidth/2 + 5);
@@ -131,9 +143,7 @@ angular.module('tabSlideBox', [])
 				
 				$scope.slideHasChanged = function(index){
 					$scope.events.trigger("slideChange", {"index" : index});
-					$timeout(function(){
-						if($scope.onSlideMove) $scope.onSlideMove({"index" : eval(index)});
-					},100);
+					$timeout(function(){if($scope.onSlideMove) $scope.onSlideMove({"index" : eval(index)});},100);
 				};
 				
 				$scope.$on('ngRepeatFinished', function(ngRepeatFinishedEvent) {

--- a/tabbedSlideBox/tabSlideBox.js
+++ b/tabbedSlideBox/tabSlideBox.js
@@ -131,7 +131,9 @@ angular.module('tabSlideBox', [])
 				
 				$scope.slideHasChanged = function(index){
 					$scope.events.trigger("slideChange", {"index" : index});
-					$timeout(function(){$scope.onSlideMove({"index" : eval(index)});},100);
+					$timeout(function(){
+						if($scope.onSlideMove) $scope.onSlideMove({"index" : eval(index)});
+					},100);
 				};
 				
 				$scope.$on('ngRepeatFinished', function(ngRepeatFinishedEvent) {


### PR DESCRIPTION
Testing if **onSlideMove** is declared on $scope before trying to call it to prevent from exception if it's not.
And managing ON and OFF states on tabs to mimic the default behavior of **ion-tab**.
For example, intead of having this in the template :
```html
<a href="javascript:;" class="ion-ios-pulse"></a>
<a href="javascript:;" class="ion-ios-location-outline"></a>
```

The user could set the following :
```html
<a href="javascript:;" icon-off="ion-ios-pulse" icon-on="ion-ios-pulse-strong"></a>
<a href="javascript:;" icon-off="ion-ios-location-outline" icon-on="ion-ios-location"></a>
```

**icon-off** will be set at init, then it will toggle between **icon-on** and **icon-off**.
I kept the **"active"** css to make things easier.